### PR TITLE
hotfix/tags_cant_be_numeric_value_solution_auto_string_casting

### DIFF
--- a/src/Support/Span.php
+++ b/src/Support/Span.php
@@ -36,6 +36,7 @@ class Span
         $this->tags = collect($this->tagProviders)
             ->map(fn (string $tagProvider) => app($tagProvider))
             ->flatMap(fn (TagProvider $tagProvider) => $tagProvider->tags())
+            ->mapWithKeys(fn ($value, $key) => [$key => (string) $value])
             ->toArray();
 
         $this->mergeProperties = $mergeProperties;

--- a/src/Support/Trace.php
+++ b/src/Support/Trace.php
@@ -27,6 +27,7 @@ class Trace
         $this->tags = collect($tagProviders)
             ->map(fn (string $tagProvider) => app($tagProvider))
             ->flatMap(fn (TagProvider $tagProvider) => $tagProvider->tags())
+            ->mapWithKeys(fn ($value, $key) => [$key => (string) $value])
             ->toArray();
     }
 


### PR DESCRIPTION
Test tag: 
```
"test0" => 1,
```

Without my solution:

![image](https://github.com/spatie/laravel-open-telemetry/assets/52620406/78bc9e00-be63-4f77-8d13-7f3c22ff84ba)


With my solution

![image](https://github.com/spatie/laravel-open-telemetry/assets/52620406/586e5426-752d-46b6-be75-04c4f54138ea)
